### PR TITLE
QuillInjector#Destroy()で破棄されないオブジェクトがある不具合修正。

### DIFF
--- a/s2container.net/source/Seasar.DynamicProxy/Seasar.Framework.Aop/Proxy/DynamicAopProxy.cs
+++ b/s2container.net/source/Seasar.DynamicProxy/Seasar.Framework.Aop/Proxy/DynamicAopProxy.cs
@@ -41,7 +41,7 @@ namespace Seasar.Framework.Aop.Proxy
     {
         #region fields
 
-        private readonly ProxyGenerator _generator;
+        private static readonly ProxyGenerator _generator = new ProxyGenerator();
         private readonly IAspect[] _aspects;
         private readonly Hashtable _interceptors = new Hashtable();
         private readonly Type _type;
@@ -94,7 +94,6 @@ namespace Seasar.Framework.Aop.Proxy
             _type = type;
             _aspects = aspects;
             _parameters = parameters;
-            _generator = new ProxyGenerator();
 
             if (_type.IsInterface)
             {


### PR DESCRIPTION
AspectされているオブジェクトをQuillInjectorに管理させている場合、
QuillInjector#Destroyでも破棄されないオブジェクトがあります。
Castle.DynamicProxyのProxyGeneratorのバグですが、newするたびにリークします。

http://stackoverflow.com/questions/19569435/is-there-a-memory-leak-when-using-structuremap-with-castle-dynamicproxy
